### PR TITLE
modify urllib version.

### DIFF
--- a/youtube.py
+++ b/youtube.py
@@ -9,8 +9,8 @@ import json
 import signal
 import argparse
 
-from urlparse import unquote
-from urllib2 import urlopen
+from urllib.parse import unquote
+from urllib.request import urlopen
 
 
 CHUNK_SIZE = 16 * 1024  # 16 Kb
@@ -146,7 +146,7 @@ def get_videos(my_url):
 def download(url, filename):
     response = urlopen(url)
     bytes_received = 0
-    download_size = int(response.info().getheader("Content-Length"))
+    download_size = int(response.getheader("Content-Length"))
 
     with open(filename, 'wb') as dst_file:
         while True:


### PR DESCRIPTION
The urllib2 module has been split across several modules in Python 3 named urllib.request and urllib.error. 
(https://docs.python.org/2/library/urllib2.html?highlight=urllib#module-urllib2)
currently, there is no urllib2 in 'pip install'.  i can't find rullib2 in 'pip install'. 
so i change import urllib2 -> urllib.request.
and modify response.info().getheader() -> response.getheader() by updated urllib

thank you for reading.!